### PR TITLE
example of a non local gateway

### DIFF
--- a/examples/log-properties.js
+++ b/examples/log-properties.js
@@ -11,6 +11,7 @@ const token = '';
 
 (async () => {
     const webThingsClient = await WebThingsClient.local(token);
+    // const webThingsClient = new WebThingsClient("gateway.local", 80, token);
     const devices = await webThingsClient.getDevices();
 
     for (const device of devices) {


### PR DESCRIPTION
added `const webThingsClient = new WebThingsClient("gateway.local", 80, token);` so that others won't have to dig what the constructor expects