### PR TITLE
Add support for global things socket (and maybe one or two other things)

### DIFF
--- a/examples/log-properties.js
+++ b/examples/log-properties.js
@@ -11,7 +11,7 @@ const token = '';
 
 (async () => {
     const webThingsClient = await WebThingsClient.local(token);
-    // const webThingsClient = new WebThingsClient("gateway.local", 80, token);
+    // const webThingsClient = new WebThingsClient('gateway.local', 80, token);
     const devices = await webThingsClient.getDevices();
 
     for (const device of devices) {

--- a/examples/monitor-device.js
+++ b/examples/monitor-device.js
@@ -35,7 +35,7 @@ const token = '';
         device.on('connectStateChanged', (state) => {
             console.log(device.id(), ':', state ? 'connected' : 'disconnected');
         });
-        device.on('thingModified', () => {
+        device.on('deviceModified', () => {
             console.log(device.id(), ':', 'modified');
         });
         device.connect().then(() => {

--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -1,0 +1,60 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
+ */
+
+const { WebThingsClient } = require('../lib/webthings-client');
+
+// Create a token at http://[your-gateway]/oauth/authorize?response_type=code&client_id=local-token&scope=/things:readwrite
+const token = '';
+
+(async () => {
+    const webThingsClient = await WebThingsClient.local(token);
+
+    webThingsClient.on('connectFailed', (device_id) => {
+        console.log(device_id, ':', 'Failed to connect');
+    });
+    webThingsClient.on('error', (error) => {
+        console.log('Something went wrong', error);
+    });
+    webThingsClient.on('close', () => {
+        console.log('Connection closed');
+    });
+    webThingsClient.on('propertyChanged', (device_id, property_name, value) => {
+        console.log(device_id, ':', `Property ${property_name} changed to ${value}`);
+    });
+    webThingsClient.on('actionTriggered', (device_id, action_name, info) => {
+        console.log(device_id, ':', `Action ${action_name} triggered with input ${JSON.stringify(info.input)}`);
+    });
+    webThingsClient.on('eventRaised', (device_id, event_name, info) => {
+        console.log(device_id, ':', `Event ${event_name} raised: ${info.data}`);
+    });
+    webThingsClient.on('connectStateChanged', (device_id, state) => {
+        console.log(device_id, ':', state ? 'connected' : 'disconnected');
+    });
+    webThingsClient.on('thingModified', (device_id) => {
+        console.log(device_id, ':', 'modified');
+    });
+    webThingsClient.on('thingAdded', async (device_id) => {
+        console.log(device_id, ':', 'added');
+        const device = await webThingsClient.getDevice(device_id);
+        await webThingsClient.subscribeEvents(device, device.events);
+        console.log(device.id(), ':', 'Subscribed to all events');
+    });
+    webThingsClient.on('thingRemoved', (device_id) => {
+        console.log(device_id, ':', 'removed');
+    });
+    webThingsClient.on('pair', (info) => {
+        console.log('pair', info.status);
+    });
+    webThingsClient.connect().then(() => {
+        setTimeout(async () => {
+            const devices = await webThingsClient.getDevices();
+            for (const device of devices) {
+                await webThingsClient.subscribeEvents(device, device.events);
+                console.log(device.id(), ':', 'Subscribed to all events');
+            }
+        }, 100);
+    });
+})();

--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -48,13 +48,13 @@ const token = '';
     webThingsClient.on('pair', (info) => {
         console.log('pair', info.status);
     });
-    webThingsClient.connect().then(() => {
-        setTimeout(async () => {
-            const devices = await webThingsClient.getDevices();
-            for (const device of devices) {
-                await webThingsClient.subscribeEvents(device, device.events);
-                console.log(device.id(), ':', 'Subscribed to all events');
-            }
-        }, 100);
-    });
+    
+    await webThingsClient.connect();
+    setTimeout(async () => {
+        const devices = await webThingsClient.getDevices();
+        for (const device of devices) {
+            await webThingsClient.subscribeEvents(device, device.events);
+            console.log(device.id(), ':', 'Subscribed to all events');
+        }
+    }, 100);
 })();

--- a/examples/monitor.js
+++ b/examples/monitor.js
@@ -33,16 +33,16 @@ const token = '';
     webThingsClient.on('connectStateChanged', (device_id, state) => {
         console.log(device_id, ':', state ? 'connected' : 'disconnected');
     });
-    webThingsClient.on('thingModified', (device_id) => {
+    webThingsClient.on('deviceModified', (device_id) => {
         console.log(device_id, ':', 'modified');
     });
-    webThingsClient.on('thingAdded', async (device_id) => {
+    webThingsClient.on('deviceAdded', async (device_id) => {
         console.log(device_id, ':', 'added');
         const device = await webThingsClient.getDevice(device_id);
         await webThingsClient.subscribeEvents(device, device.events);
         console.log(device.id(), ':', 'Subscribed to all events');
     });
-    webThingsClient.on('thingRemoved', (device_id) => {
+    webThingsClient.on('deviceRemoved', (device_id) => {
         console.log(device_id, ':', 'removed');
     });
     webThingsClient.on('pair', (info) => {

--- a/src/action-instance.ts
+++ b/src/action-instance.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { Action } from "./action";
+import { Action } from './action';
 
 export interface ActionInstanceDescription {
     input: { [key: string]: any };

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,11 +4,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { Link } from "./link";
-import { Device } from "./device";
-import { Property } from "./property";
-import { ActionInstance, ActionInstanceDescription } from "./action-instance";
-import { hrefFromLinksArray } from "./helpers";
+import { Link } from './link';
+import { Device } from './device';
+import { Property } from './property';
+import { ActionInstance, ActionInstanceDescription } from './action-instance';
+import { hrefFromLinksArray } from './helpers';
 
 export interface ActionDescription {
     title: string;

--- a/src/device.ts
+++ b/src/device.ts
@@ -78,7 +78,7 @@ export class Device extends EventEmitter {
     }
     public async connect(port = 8080) {
         const href = this.href();
-        const socketUrl  = `ws://localhost:${port}${href}`;
+        const socketUrl  = `ws://${this.client.address}:${port}${href}`;
         const webSocketClient = new WebSocketClient();
 
         webSocketClient.on('connectFailed', (error: any) => {

--- a/src/device.ts
+++ b/src/device.ts
@@ -35,7 +35,7 @@ export class Device extends EventEmitter {
     public properties: { [key: string]: Property } = {};
     public actions: { [key: string]: Action } = {};
     public events: { [key: string]: Event } = {};
-    public connection?: any;
+    private connection?: any;
     constructor(public description: DeviceDescription, public client: WebThingsClient) {
         super();
         for (const propertyName in description.properties) {
@@ -144,6 +144,12 @@ export class Device extends EventEmitter {
 
             webSocketClient.connect(`${socketUrl }?jwt=${this.client.token}`);
         });
+    }
+    public async disconnect() {
+        if (!this.connection) {
+            throw Error('Socket not connected!');
+        }
+        this.connection.close();
     }
     public async subscribeEvents(events: { [key: string]: Event }) {
         if (!this.connection) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -99,7 +99,7 @@ export class Device extends EventEmitter {
                     if (message.type === 'utf8' && message.utf8Data) {
                         const msg = JSON.parse(message.utf8Data);
                         this.emit('message', msg.data);
-                        if (msg.id && msg.data) {
+                        if ('id' in msg && 'data' in msg) {
                             switch (msg.messageType) {
                                 case 'propertyStatus':
                                     for (const key in msg.data) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -78,7 +78,7 @@ export class Device extends EventEmitter {
     }
     public async connect(port = 8080) {
         const href = this.href();
-        const thingUrl = `ws://localhost:${port}${href}`;
+        const socketUrl  = `ws://localhost:${port}${href}`;
         const webSocketClient = new WebSocketClient();
 
         webSocketClient.on('connectFailed', (error: any) => {
@@ -129,7 +129,7 @@ export class Device extends EventEmitter {
                                     this.emit('connectStateChanged', msg.data);
                                     break;
                                 case 'thingModified':
-                                    this.emit('thingModified', msg.data);
+                                    this.emit('deviceModified', msg.data);
                                     break;
                                 default:
                                     console.warn('Unknown message from device', this.id(), ':', msg.messageType, '(', msg.data, ')');
@@ -142,7 +142,7 @@ export class Device extends EventEmitter {
                 resolve();
             });
 
-            webSocketClient.connect(`${thingUrl}?jwt=${this.client.token}`);
+            webSocketClient.connect(`${socketUrl }?jwt=${this.client.token}`);
         });
     }
     public async subscribeEvents(events: { [key: string]: Event }) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -6,7 +6,7 @@
 
 import { WebThingsClient } from './webthings-client';
 import { EventEmitter } from 'events';
-import { client as WebSocketClient } from 'websocket';
+import { client as WebSocketClient, connection as WebSocketConnection } from 'websocket';
 import { PropertyDescription, Property } from './property';
 import { ActionDescription, Action } from './action';
 import { EventDescription, Event } from './event';
@@ -35,7 +35,7 @@ export class Device extends EventEmitter {
     public properties: { [key: string]: Property } = {};
     public actions: { [key: string]: Action } = {};
     public events: { [key: string]: Event } = {};
-    private connection?: any;
+    private connection?: WebSocketConnection;
     constructor(public description: DeviceDescription, public client: WebThingsClient) {
         super();
         for (const propertyName in description.properties) {
@@ -86,7 +86,7 @@ export class Device extends EventEmitter {
         });
 
         await new Promise((resolve) => {
-            webSocketClient.on('connect', async (connection: any) => {
+            webSocketClient.on('connect', async (connection: WebSocketConnection) => {
                 connection.on('error', (error: any) => {
                     this.emit('error', error);
                 });

--- a/src/device.ts
+++ b/src/device.ts
@@ -4,16 +4,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { WebThingsClient } from "./webthings-client";
-import { EventEmitter } from "events";
-import { client as WebSocketClient } from "websocket";
-import { PropertyDescription, Property } from "./property";
-import { ActionDescription, Action } from "./action";
-import { EventDescription, Event } from "./event";
-import { Link } from "./link";
-import { EventInstance, EventInstanceDescription } from "./event-instance";
-import { ActionInstance, ActionInstanceDescription } from "./action-instance";
-import { hrefFromLinksArray } from "./helpers";
+import { WebThingsClient } from './webthings-client';
+import { EventEmitter } from 'events';
+import { client as WebSocketClient } from 'websocket';
+import { PropertyDescription, Property } from './property';
+import { ActionDescription, Action } from './action';
+import { EventDescription, Event } from './event';
+import { Link } from './link';
+import { EventInstance, EventInstanceDescription } from './event-instance';
+import { ActionInstance, ActionInstanceDescription } from './action-instance';
+import { hrefFromLinksArray } from './helpers';
 
 export interface DeviceDescription {
     title: string;

--- a/src/event-instance.ts
+++ b/src/event-instance.ts
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { Event } from "./event";
+import { Event } from './event';
 
 export interface EventInstanceDescription {
     data?: any;

--- a/src/event.ts
+++ b/src/event.ts
@@ -4,10 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { Link } from "./link";
-import { Device } from "./device";
-import { EventInstance, EventInstanceDescription } from "./event-instance";
-import { hrefFromLinksArray } from "./helpers";
+import { Link } from './link';
+import { Device } from './device';
+import { EventInstance, EventInstanceDescription } from './event-instance';
+import { hrefFromLinksArray } from './helpers';
 
 export interface EventDescription {
     title: string;

--- a/src/property.ts
+++ b/src/property.ts
@@ -4,9 +4,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.*
  */
 
-import { Link } from "./link";
-import { Device } from "./device";
-import { hrefFromLinksArray } from "./helpers";
+import { Link } from './link';
+import { Device } from './device';
+import { hrefFromLinksArray } from './helpers';
 
 export interface PropertyDescription {
     title: string;

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -34,7 +34,7 @@ export class WebThingsClient extends EventEmitter {
 
     private protocol: string;
     private fetchOptions: RequestInit = {};
-    public connection?: any;
+    private connection?: any;
 
     constructor(private address: string, private port: number, public token: string, useHttps = false, skipValidation = false) {
         super();
@@ -184,6 +184,13 @@ export class WebThingsClient extends EventEmitter {
 
             webSocketClient.connect(`${socketUrl}?jwt=${this.token}`);
         });
+    }
+
+    public async disconnect() {
+        if (!this.connection) {
+            throw Error('Socket not connected!');
+        }
+        this.connection.close();
     }
 
     public async subscribeEvents(device: Device, events: { [key: string]: Event }) {

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -132,7 +132,7 @@ export class WebThingsClient extends EventEmitter {
                     if (message.type === 'utf8' && message.utf8Data) {
                         const msg = JSON.parse(message.utf8Data);
                         this.emit('message', msg.id, msg.data);
-                        if (msg.id && msg.data) {
+                        if ('id' in msg && 'data' in msg) {
                             switch (msg.messageType) {
                                 case 'propertyStatus':
                                     for (const key in msg.data) {
@@ -164,7 +164,7 @@ export class WebThingsClient extends EventEmitter {
                                 default:
                                     console.warn('Unknown message from socket', msg.id || '', ':', msg.messageType, '(', msg.data, ')');
                             }
-                        } else if (msg.data) {
+                        } else if ('data' in msg) {
                             switch (msg.messageType) {
                                 case 'actionStatus':
                                     if (Object.keys(msg.data).length == 1 && Object.keys(msg.data)[0] == 'pair') {

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -6,7 +6,7 @@
 
 import fetch, { RequestInit } from 'node-fetch';
 import { EventEmitter } from 'events';
-import { client as WebSocketClient } from 'websocket';
+import { client as WebSocketClient, connection as WebSocketConnection } from 'websocket';
 import { Device, DeviceDescription } from './device';
 import { Event, EventDescription } from './event';
 import { Agent } from 'https';
@@ -34,7 +34,7 @@ export class WebThingsClient extends EventEmitter {
 
     private protocol: string;
     private fetchOptions: RequestInit = {};
-    private connection?: any;
+    private connection?: WebSocketConnection;
 
     constructor(public address: string, private port: number, public token: string, useHttps = false, skipValidation = false) {
         super();
@@ -119,7 +119,7 @@ export class WebThingsClient extends EventEmitter {
         });
 
         await new Promise((resolve) => {
-            webSocketClient.on('connect', async (connection: any) => {
+            webSocketClient.on('connect', async (connection: WebSocketConnection) => {
                 connection.on('error', (error: any) => {
                     this.emit('error', error);
                 });

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -5,10 +5,13 @@
  */
 
 import fetch, { RequestInit } from 'node-fetch';
+import { EventEmitter } from "events";
+import { client as WebSocketClient } from "websocket";
 import { Device, DeviceDescription } from './device';
+import { Event, EventDescription } from './event';
 import { Agent } from 'https';
 
-export class WebThingsClient {
+export class WebThingsClient extends EventEmitter {
     public static async local(token: string) {
         let address = 'localhost';
         let port = 8080;
@@ -31,8 +34,10 @@ export class WebThingsClient {
 
     private protocol: string;
     private fetchOptions: RequestInit = {};
+    public connection?: any;
 
     constructor(private address: string, private port: number, public token: string, useHttps = false, skipValidation = false) {
+        super();
         this.protocol = useHttps ? 'https' : 'http';
 
         if (skipValidation) {
@@ -47,6 +52,11 @@ export class WebThingsClient {
     public async getDevices(): Promise<Device[]> {
         const descriptions: DeviceDescription[] = await this.get('/things');
         return descriptions.map(description => new Device(description, this));
+    }
+
+    public async getDevice(id: string): Promise<Device> {
+        const description: DeviceDescription = await this.get(`/things/${id}`);
+        return new Device(description, this);
     }
 
     private async request(method: string, path: string, body: any, args: { [key: string]: any } = {}) {
@@ -98,5 +108,92 @@ export class WebThingsClient {
 
     public async delete(path: string) {
         this.request('DELETE', path, '', { strbody: true, expectnocontent: true });
+    }
+
+    public async connect(port = 8080) {
+        const socketUrl = `ws://localhost:${port}/things`;
+        const webSocketClient = new WebSocketClient();
+
+        webSocketClient.on('connectFailed', (error: any) => {
+            this.emit('connectFailed', error);
+        });
+
+        await new Promise((resolve) => {
+            webSocketClient.on('connect', async (connection: any) => {
+                connection.on('error', (error: any) => {
+                    this.emit('error', error);
+                });
+
+                connection.on('close', () => {
+                    this.emit('close');
+                });
+
+                connection.on('message', (message: any) => {
+                    if (message.type === 'utf8' && message.utf8Data) {
+                        const msg = JSON.parse(message.utf8Data);
+                        this.emit('message', msg.id, msg.data);
+                        if (msg.id && msg.data) {
+                            switch (msg.messageType) {
+                                case 'propertyStatus':
+                                    for (const key in msg.data) {
+                                        this.emit('propertyChanged', msg.id, key, msg.data[key]);
+                                    }
+                                    break;
+                                case 'actionStatus':
+                                    for (const key in msg.data) {
+                                        this.emit('actionTriggered', msg.id, key, msg.data[key]);
+                                    }
+                                    break;
+                                case 'event':
+                                    for (const key in msg.data) {
+                                        this.emit('eventRaised', msg.id, key, msg.data[key]);
+                                    }
+                                    break;
+                                case 'connected':
+                                    this.emit('connectStateChanged', msg.id, msg.data);
+                                    break;
+                                case 'thingModified':
+                                    this.emit('thingModified', msg.id, msg.data);
+                                    break;
+                                case 'thingAdded':
+                                    this.emit('thingAdded', msg.id, msg.data);
+                                    break;
+                                case 'thingRemoved':
+                                    this.emit('thingRemoved', msg.id, msg.data);
+                                    break;
+                                default:
+                                    console.warn('Unknown message from socket', msg.id || '', ':', msg.messageType, '(', msg.data, ')');
+                            }
+                        } else if (msg.data) {
+                            switch (msg.messageType) {
+                                case 'actionStatus':
+                                    if (Object.keys(msg.data).length == 1 && Object.keys(msg.data)[0] == 'pair') {
+                                        this.emit('pair', msg.data.pair);
+                                    }
+                                    break;
+                                default:
+                                    console.warn('Unknown message from socket', msg.id || '', ':', msg.messageType, '(', msg.data, ')');
+                            }
+                        }
+                    }
+                });
+
+                this.connection = connection;
+                resolve();
+            });
+
+            webSocketClient.connect(`${socketUrl}?jwt=${this.token}`);
+        });
+    }
+
+    public async subscribeEvents(device: Device, events: { [key: string]: Event }) {
+        if (!this.connection) {
+            throw Error('Socket not connected!');
+        }
+        const eventdescs: { [key: string]: EventDescription } = {};
+        for (const eventName in events) {
+            eventdescs[eventName] = events[eventName].description;
+        }
+        await this.connection.send(JSON.stringify({ messageType: 'addEventSubscription', id: device.id(), data: eventdescs }));
     }
 }

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -29,14 +29,14 @@ export class WebThingsClient extends EventEmitter {
             console.log(`HTTPS seems to be active, using port ${port} instead`);
         }
 
-        return new WebThingsClient('localhost', port, token, https, skipValidation);
+        return new WebThingsClient(address, port, token, https, skipValidation);
     }
 
     private protocol: string;
     private fetchOptions: RequestInit = {};
     private connection?: any;
 
-    constructor(private address: string, private port: number, public token: string, useHttps = false, skipValidation = false) {
+    constructor(public address: string, private port: number, public token: string, useHttps = false, skipValidation = false) {
         super();
         this.protocol = useHttps ? 'https' : 'http';
 
@@ -111,7 +111,7 @@ export class WebThingsClient extends EventEmitter {
     }
 
     public async connect(port = 8080) {
-        const socketUrl = `ws://localhost:${port}/things`;
+        const socketUrl = `ws://${this.address}:${port}/things`;
         const webSocketClient = new WebSocketClient();
 
         webSocketClient.on('connectFailed', (error: any) => {

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -5,8 +5,8 @@
  */
 
 import fetch, { RequestInit } from 'node-fetch';
-import { EventEmitter } from "events";
-import { client as WebSocketClient } from "websocket";
+import { EventEmitter } from 'events';
+import { client as WebSocketClient } from 'websocket';
 import { Device, DeviceDescription } from './device';
 import { Event, EventDescription } from './event';
 import { Agent } from 'https';
@@ -19,10 +19,10 @@ export class WebThingsClient extends EventEmitter {
         let skipValidation = false;
         console.log(`Probing port ${port}`);
         const response = await fetch(`http://${address}:${port}`, {
-            redirect: "manual"
+            redirect: 'manual'
         });
 
-        if (response.headers.get("Location")) {
+        if (response.headers.get('Location')) {
             port = 4443;
             https = true;
             skipValidation = true;

--- a/src/webthings-client.ts
+++ b/src/webthings-client.ts
@@ -153,13 +153,13 @@ export class WebThingsClient extends EventEmitter {
                                     this.emit('connectStateChanged', msg.id, msg.data);
                                     break;
                                 case 'thingModified':
-                                    this.emit('thingModified', msg.id, msg.data);
+                                    this.emit('deviceModified', msg.id, msg.data);
                                     break;
                                 case 'thingAdded':
-                                    this.emit('thingAdded', msg.id, msg.data);
+                                    this.emit('deviceAdded', msg.id, msg.data);
                                     break;
                                 case 'thingRemoved':
-                                    this.emit('thingRemoved', msg.id, msg.data);
+                                    this.emit('deviceRemoved', msg.id, msg.data);
                                     break;
                                 default:
                                     console.warn('Unknown message from socket', msg.id || '', ':', msg.messageType, '(', msg.data, ')');


### PR DESCRIPTION
Finally figured out how to find out when devices got added / removed.
I am not 100% certain whether this is the best possible solution, but it seemed to me like the most reasonable one: Since getting the device instances + their properties from the global webthings client requires a (likely redundant) call to getDevices (which is sometimes not even possible, specifically after thingRemoved), I decided to just emit the IDs of affected things as strings.